### PR TITLE
WS-2589: "Remove genre option from entities example"

### DIFF
--- a/R/Api.R
+++ b/R/Api.R
@@ -322,7 +322,7 @@ get_user_agent <- function() {
 serialize_parameters <- function(parameters) {
   serialized_params <- list()
   for (param in names(parameters)) {
-    if (param == "genre" || param == "profileId" || param == "language" ||
+    if (param == "profileId" || param == "language" ||
         param == "content" || param == "options" || param == "contentUri" ||
         param == "content_type") {
       serialized_params[[param]] <- parameters[[param]]

--- a/R/Api.R
+++ b/R/Api.R
@@ -327,6 +327,10 @@ serialize_parameters <- function(parameters) {
         param == "content_type") {
       serialized_params[[param]] <- parameters[[param]]
     }
+
+    if (param == "genre") {
+      warning("The genre parameter is deprecated and will be removed in a future release.")
+    }
   }
   return(jsonlite::toJSON(serialized_params, auto_unbox = TRUE))
 }

--- a/examples/entities.R
+++ b/examples/entities.R
@@ -16,7 +16,7 @@ entities_text_data <- "The Securities and Exchange Commission today announced th
 
 parameters <- list()
 parameters[["content"]] <- entities_text_data
-parameters[["genre"]] <- "social-media"
+
 # advanced output
 url_parameters <- list(output = "rosette")
 


### PR DESCRIPTION
This PR is needed to remove the genre option from the examples and source code.